### PR TITLE
Update SparkJobRunner.java

### DIFF
--- a/hrds_H/src/main/java/hrds/h/biz/spark/running/SparkJobRunner.java
+++ b/hrds_H/src/main/java/hrds/h/biz/spark/running/SparkJobRunner.java
@@ -95,7 +95,8 @@ public class SparkJobRunner {
      * @return 合法参数字符串
      */
     static String obtainSatisfyShellString(String convertedShellArg) {
-        return convertedShellArg.replace("^", "\"");
+        return convertedShellArg.replace("\"", "")
+                .replace("^", "\"");
     }
 
 }


### PR DESCRIPTION
修复因为环境变量不同造成的双引号出现，从而出现的转对象失败问题